### PR TITLE
Fixed player multi spawn bug

### DIFF
--- a/Assets/Scripts/Player/PlayerStateController.cs
+++ b/Assets/Scripts/Player/PlayerStateController.cs
@@ -86,6 +86,10 @@ public partial class PlayerStateController : MonoBehaviour
         if (liftedObject)
             liftedObject.GetComponent<Interactable>().Interact(this);
 
+        // Prevent dying multiple times in single frame.
+        if (CurrentState == PlayerStates.DEAD)
+            return;
+
         SetState(PlayerStates.DEAD);
         manager.RespawnPlayer(1f);
 


### PR DESCRIPTION
There is a spawn bug when multiple towers or enemies kill the player at the same time.
Die is being called multiple times, therefore the player is getting spawned multiple times. This happens more often when the game gets laggy.

The fix prevents this with an if check.