### PR TITLE
Remove UI wheel on death immediately

### DIFF
--- a/Assets/Scripts/Player/PlayerStateController.cs
+++ b/Assets/Scripts/Player/PlayerStateController.cs
@@ -209,6 +209,7 @@ public partial class PlayerStateController : MonoBehaviour
                 break;
             case PlayerStates.IN_TURRET_MENU:
                 anim.SetBool(planningAnimatorParam, false);
+                ui.SetActiveUI(false);
                 break;
         }
 

--- a/Assets/Scripts/Player/PlayerUi.cs
+++ b/Assets/Scripts/Player/PlayerUi.cs
@@ -32,6 +32,11 @@ public class PlayerUi : MonoBehaviour
         messageUI = GetComponent<MessageUI>();
     }
 
+    public void SetActiveUI(bool value)
+    {
+            ui.SetActive(value);
+    }
+
     void LateUpdate()
     {
         //Points the UI to the main camera


### PR DESCRIPTION
Fixed a bug where selectwheel ui wouldn't be instantly removed from player on death.